### PR TITLE
Remove R15 from user cases.

### DIFF
--- a/Use Case Documentation.md
+++ b/Use Case Documentation.md
@@ -131,16 +131,6 @@
 | Flow: | - |
 | Post-conditions: | - |
 
-| Use case id: | R15 |
-| :--- | :--- |
-| Use case name: | Create Game Instance |
-| Overview: | - |
-| Primary actors: | - |
-| Properties: | - |
-| Pre-conditions: | - |
-| Flow: | - |
-| Post-conditions: | - |
-
 | Use case id: | R16 |
 | :--- | :--- |
 | Use case name: | Save Game State |


### PR DESCRIPTION
R15: Create Game Instance is redundant with R3: Create Match.
The "system" will have to allocate resources for the game, but that is purely the system and does not have any actors attached to it.