### PR TITLE
Update first half of the use cases

### DIFF
--- a/UseCaseDocumentation.md
+++ b/UseCaseDocumentation.md
@@ -15,7 +15,7 @@
 | Overview: | The user signs into their prexisting account with username and password |
 | Actors: | User [primary, initiator], Database |
 | Pre-conditions: | User is prompted to either sign in or register. The user chooses sign in. |
-| Flow: | **Main Flow** <br> 1. User enters a username and a password. <br> 2. User attempts to sign in. <br> 3. User is informed of the successful sign in attempt and the session is saved in the database. <br> 4. The user is redirected to the lobby. <br> **Alternate Flows** <br> 3a. User is informed of the invalid sign in attempt. <br> 4a. User is allowed another attempt. <br> 3b. User is informed that the given username is not associated to an account. <br> 4b. User is allowed another attempt. |
+| Flow: | **Main Flow**: <br> 1. User enters a username and a password. <br> 2. User attempts to sign in. <br> 3. Database informs the user that the username and password combination is valid and the session is saved in the database. <br> 4. The user is redirected to the lobby. <br> **Alternate Flows**: <br> 3a. Invalid sign in <br> 3a1. Database informs the user that the username and password combination is invalid. <br><br> 3a2. User is allowed another attempt. Return to 1. <br> 3b. Inexistent username <br> 3b1. Database informs user that the username provided is not associated to an account. <br> 3b2. User is allowed another attempt. Return to 1. |
 | Post-conditions: | User signs into their preexisting account |
 
 | Use case id: | R3 |
@@ -113,8 +113,8 @@
 | Use case name: | Record Match History |
 | Overview: | The results of the match are stored in the database |
 | Actors: | Database [primary], User [initiator] |
-| Pre-conditions: | The match has ended. |
-| Flow: | **Main Flow**: 1. The start and end times and dates are recorded to the database. <br> 2. The winner and loser are recorded to the database. <br> **Alternate Flows**: 2a. The user that quit the match is recorded to the database as the loser and the other user is recorded as the winner. <br> 3a. The user that quit is recorded to have withdrawn from the match. |
+| Pre-conditions: | The match has ended |
+| Flow: | **Main Flow**: <br> 1. The start and end times and dates are recorded to the database. <br> 2. The winner and loser are recorded to the database. <br> **Alternate Flows**: <br> 2a A user quits <br> 2a1. The user that quit the match is recorded to the database as the loser and the other user is recorded as the winner. <br> 2a2. The user that quit is recorded to have withdrawn from the match. |
 | Post-conditions: | The times, dates and results are stored in the database |
 
 | Use case id: | R14 |

--- a/UseCaseDocumentation.md
+++ b/UseCaseDocumentation.md
@@ -5,79 +5,82 @@
 | Use case name: | Register |
 | Overview: | The user registers an account with their email, username, and password |
 | Actors: | User [primary, initiator], Database |
-| Pre-conditions: | User is prompted to either sign in or register. The user chooses register. |
+| Pre-conditions: | User was prompted to either sign in or register. The user chose register. |
 | Main Flow: | 1. User enters an email, a username, and a password. <br> 2. User attempts to register. <br> 3. Database informs the user that the email, username and password provided are all valid. <br> 4. Database records the new account. <br> 5. User is automatically signed into the new account. |
 | Post-conditions: | User is signed into the new account |
-| Alternate Flows: | **3a Invalid register attempt** <br> 3a1. Database informs the user that the email, username or password provided are invalid. <br> 3a2. User is allowed another attempt. Return to 1. |
+| Alternate Flows: | **3a Invalid data** <br> 3a1. Database informs the user that the email, username or password provided are invalid. <br> 3a2. User is allowed another attempt. Return to 1. |
 
 | Use case id: | R02 |
 | :--- | :--- |
 | Use case name: | Sign In |
-| Overview: | The user signs into their prexisting account with username and password |
+| Overview: | The user signs into their preexisting account with username and password |
 | Actors: | User [primary, initiator], Database |
-| Pre-conditions: | User is prompted to either sign in or register. The user chooses sign in. |
+| Pre-conditions: | User has registered an account. <br> User was prompted to either sign in or register. The user chose sign in. |
 | Main Flow: | 1. User enters a username and a password. <br> 2. User attempts to sign in. <br> 3. Database informs the user that the username and password combination is valid. <br> 4. Database saves the session. |
-| Post-conditions: | User signs into their preexisting account |
-| Alternate Flows: | **3a Invalid sign in attempt** <br> 3a1. Database informs the user that the username and password combination is invalid. <br> 3a2. User is allowed another attempt. Return to 1. <br> **3b Inexistent username** <br> 3b1. Database informs the user that the username provided is not associated to an account. <br> 3b2. User is allowed another attempt. Return to 1. |
+| Post-conditions: | User signs into their account |
+| Alternate Flows: | **3a Invalid data** <br> 3a1. Database informs the user that the username and password combination is invalid. <br> 3a2. User is allowed another attempt. Return to 1. <br> **3b Inexistent username** <br> 3b1. Database informs the user that the username provided is not associated to an account. <br> 3b2. User is allowed another attempt. Return to 1. |
 
 | Use case id: | R03 |
 | :--- | :--- |
 | Use case name: | Create Match |
-| Overview: | The database creates a new match instance |
+| Overview: | The user creates a new match instance |
 | Actors: | User [primary, initiator], Database |
 | Pre-conditions: | User is signed in |
-| Main Flow: | 1. User chooses to start a new match. <br> 2. Database creates a new instance of match. <br> 3. Database adds the user to the match. |
-| Post-conditions: | Database creates a new match and the user is added to it |
-| Alternate Flows: | - |
+| Main Flow: | 1. User chooses to start a new match. <br> 2. Database creates a new instance of match. <br> 3. Database adds the user to the match. <br> 4. Include(Send Invite). <br> 5. User can send many invites. Return to 4. |
+| Post-conditions: | Database creates a new match with one player |
+| Alternate Flows: | **4a No invites** <br> 4a1. User does not send any invites and chooses to play the computer. <br> 4a2. Include(Start Match). |
 
 | Use case id: | R04 |
+| :--- | :--- |
+| Use case name: | Send Invite |
+| Overview: | The user invites another user to play a match |
+| Primary actors: | User [primary, initiator] |
+| Pre-conditions: | The invitation sender created a match |
+| Main Flow | 1. Inviter sends invitee an invitation to join their match. <br> 2. Database records the pending invite sent from the inviter. <br> 3. Invitee is notified of the pending invitation. |
+| Post-conditions: | User is notified of the invitation |
+| Alternate Flows: | - |
+
+| Use case id: | R05 |
+| :--- | :--- |
+| Use case name: | Accept Invite |
+| Overview: | A user accepts an invitation to play a match |
+| Primary actors: | User [primary, initiator] |
+| Pre-conditions: | User has invited the invitee |
+| Flow: | **Main Flow** <br> 1. Primary user receives invite from Initiating User <br> 2. Primary user accepts invite <br> **Alternate Flows** <br> 2a. Primary User rejects invitation |
+| Post-conditions: | Primary User is now in game with Initiating User |
+
+| Use case id: | R06 |
+| :--- | :--- |
+| Use case name: | Reject Invite |
+| Overview: | The user rejects an invitation to play a game with another user |
+| Primary actors: | User [primary, initiator] |
+| Pre-conditions: | The user is sent an invitation to play a game by another user. |
+| Flow: | Main flow: 1. The user chooses to reject the invitation and does not join the game. |
+| Post-conditions: | The user is not added to the game. |
+
+
+| Use case id: | R07 |
 | :--- | :--- |
 | Use case name: | Join Match |
 | Overview: | Invited user joins the match |
 | Primary actors: | User [primary, initiator] |
 | Pre-conditions: | User receives an invitation to play a match |
-| Flow: |**Main Flow** <br> 1. User accepts invitation to join a match. <br> 2. User is loaded into the match |
+| Main Flow: | <br> 1. User accepts invitation to join a match. <br> 2. User is loaded into the match |
 | Post-conditions: | User is now in a match |
-
-| Use case id: | R05 |
-| :--- | :--- |
-| Use case name: | Send Invite |
-| Overview: | User invites another user an invitation to play a match |
-| Primary actors: | User [primary, initiator] |
-| Pre-conditions: | Initiating user created a match |
-| Flow: | **Main Flow** <br> 1. Initiating User invites Primary User to match <br> 2. Primary User joins Match <br> **Alternate Flows** <br> 2a. Primary User does not join match 2a. Initiating user can invite a friend |
-| Post-conditions: | Primary User and Initiating User are in a match |
-
-| Use case id: | R06 |
-| :--- | :--- |
-| Use case name: | Accept Invite |
-| Overview: | Primary User receives Invitation for a match |
-| Primary actors: | User [primary, initiator] |
-| Pre-conditions: | Initiating user has created a game |
-| Flow: | **Main Flow** <br> 1. Primary user receives invite from Initiating User <br> 2. Primary user accepts invite <br> **Alternate Flows** <br> 2a. Primary User rejects invitation |
-| Post-conditions: | Primary User is now in game with Initiating User |
-
-| Use case id: | R07 |
-| :--- | :--- |
-| Use case name: | Reject Invite |
-| Overview: | The user rejects an invitation to play a game with another user |
-| Primary actors: | User[primary] |
-| Pre-conditions: | The user is sent an invitation to play a game by another user. |
-| Flow: | Main flow: 1. The user chooses to reject the invitation and does not join the game. |
-| Post-conditions: | The user is not added to the game. |
+| Alternate Flows: | - |
 
 | Use case id: | R08 |
 | :--- | :--- |
 | Use case name: | Start Match |
 | Overview: | All users are added to a new game and game is marked in progress |
-| Actors: | User [primary, initiator] <br> Database [secondary]|
+| Actors: | User [primary, initiator], Database |
 | Pre-conditions: | The minimum number of users to start the game are in game lobby |
 | Flow: | **Main Flow:** 1. The users choose to start the game<br> 2. A new game instance is made<br> 3. All users in lobby are added to the game<br> **Alternate Flow:** 1a. The users quit the lobby<br> 2a. The game lobby is removed from the Database<br> 3a. The start game use case is cancelled|
 | Post-conditions: | A new game instance is started and all users are added to the game |
 
 | Use case id: | R09 |
 | :--- | :--- |
-| Use case name: | Play Match |
+| Use case name: | Make Move |
 | Overview: | Primary User makes a move |
 | Primary actors: | User [primary, initiator] |
 | Pre-conditions: | The game has been created and started |

--- a/UseCaseDocumentation.md
+++ b/UseCaseDocumentation.md
@@ -36,7 +36,7 @@
 | Overview: | The user invites a user to play their match |
 | Primary actors: | User [primary, initiator], Database |
 | Pre-conditions: | The invitation sender created a match |
-| Main Flow: | 1. User selects a user to send an invitation to and attempts to send the invitation. <br> 2. The receiver is notified of the invitation. <br> 3. Database records invitation to all user's accounts. <br> Extension Point: Send Invite. |
+| Main Flow: | 1. User selects a user to send an invitation to, and attempts to send the invitation. <br> 2. The receiver is notified of the invitation. <br> 3. Database records invitation to all user's accounts. <br> Extension Point: Send Invite. |
 | Post-conditions: | Every valid invitation notifies the receiver |
 | Alternate Flows: | **2a Invalid: self invitation** <br> 2a1. Database informs user that they cannot send an invitation to themself. Return to 1. <br> **3b Valid: duplicate invitation** <br> 3b1. Database does not re-record an additional invitation to any user's account. |
 
@@ -76,8 +76,8 @@
 | Overview: | The match starts |
 | Actors: | User [primary, initiator], Database |
 | Pre-conditions: | The minimum number of users to start the match have been added to the match |
-| Main Flow: | Include(Save Match State) <br> Include(Notify User When It Is Their Turn) |
-| Post-conditions: | User can make the first move |
+| Main Flow: | 1. Database updates the match to reflect that it has started. <br> Include(Save Match State) <br> Include(Notify User When It Is Their Turn) |
+| Post-conditions: | User whose turn it is is able to make the first move |
 | Alternate Flow: | - |
 
 | Use case id: | R09 |
@@ -101,7 +101,7 @@
 | Use case id: | R11 |
 | :--- | :--- |
 | Use case name: | Notify User When It Is Their Turn |
-| Overview: | The opponent's turn ends and the user receives a notification that it is their turn. |
+| Overview: | The user receives a notification that it is their turn. |
 | Primary actors: | User [Primary, Initiator] |
 | Pre-conditions: | The user is playing a game and the opponent makes a move on their turn. |
 | Flow: | **Main Flow**: 1. The user receives a notification that it is their turn. |
@@ -146,12 +146,12 @@
 | Use case id: | R16 |
 | :--- | :--- |
 | Use case name: | View User Account |
-| Overview: | The user selects a . user's account to view and the selected user's data is displayed |
+| Overview: | The user selects a user's account to view and the selected user's data is displayed |
 | Actors: | Database [primary], User [initiator] |
 | Pre-conditions: | User is signed in |
-| Main Flow: | 1. User searches for a user and attempts to view it. <br> 2. Database retreives the selected user's data. <br> 3. The selected user's data is displayed. |
+| Main Flow: | 1. User searches by username and attempts to view it. <br> 2. Database retreives the selected user's account. <br> 3. The selected user's account is displayed. |
 | Post-conditions: | The selected user's account is displayed |
-| Alternate Flows: | **2a User not in database** 2a1. Database informs the user that the selected user's account does not exist. |
+| Alternate Flows: | **2a User not in database** 2a1. Database informs the user that the username is not associated to an account. |
 
 | Use case id: | R17 |
 | :--- | :--- |

--- a/UseCaseDocumentation.md
+++ b/UseCaseDocumentation.md
@@ -56,8 +56,8 @@
 | Overview: | A user rejects an invite to play a match |
 | Primary actors: | User [primary, initiator], Database |
 | Pre-conditions: | The receiving user was notified of the invitation |
-| Main Flow: | 1. The receiver is prompted to either accept or reject the invitation, and choose to reject. <br> 2. Database informs the sender that the invitation has been rejected. <br> 3. Database deletes the invitation from both user's accounts. |
-| Post-conditions: | - |
+| Main Flow: | 1. The receiver is prompted to either accept or reject the invitation, and chooses to reject. <br> 2. Database informs the sender that the invitation has been rejected. <br> 3. Database deletes the invitation from both user's accounts. |
+| Post-conditions: | Receiving user does not have any invitations from the sending user |
 | Alternate Flows: | - |
 
 | Use case id: | R07 |
@@ -66,18 +66,19 @@
 | Overview: | All of the sending user's pending invites are cancelled |
 | Primary actors: | Database [primary, initiator] |
 | Pre-conditions: | An invitation has been accepted by a receiver |
-| Main Flow: | 1. Database selects a sent invite from the sending user's account. <br> 2. Database informs the receiving user that the invite has been cancelled. <br> 3. Database deletes the pending invite from both user's accounts. <br> Extension Point: Cancel All Outstanding Invitations |
+| Main Flow: | 1. Database selects a sent invite from the sending user's account. <br> 2. Database informs the receiving user that the invitation has been cancelled. <br> 3. Database removes the pending invite from both user's accounts. <br> Extension Point: Cancel All Outstanding Invitations |
 | Post-conditions: | The invitation sender's account does not contain pending sent invitations |
 | Alternate Flows: | - |
 
 | Use case id: | R08 |
 | :--- | :--- |
 | Use case name: | Start Match |
-| Overview: | All users are added to a new game and game is marked in progress |
+| Overview: | The match starts |
 | Actors: | User [primary, initiator], Database |
-| Pre-conditions: | The minimum number of users to start the game are in game lobby |
-| Flow: | **Main Flow:** 1. The users choose to start the game<br> 2. A new game instance is made<br> 3. All users in lobby are added to the game<br> **Alternate Flow:** 1a. The users quit the lobby<br> 2a. The game lobby is removed from the Database<br> 3a. The start game use case is cancelled|
-| Post-conditions: | A new game instance is started and all users are added to the game |
+| Pre-conditions: | The minimum number of users to start the match have been added to the match |
+| Main Flow: | Include(Save Match State) <br> Include(Notify User When It Is Their Turn) |
+| Post-conditions: | User can make the first move |
+| Alternate Flow: | - |
 
 | Use case id: | R09 |
 | :--- | :--- |
@@ -85,7 +86,7 @@
 | Overview: | Primary User makes a move |
 | Primary actors: | User [primary, initiator] |
 | Pre-conditions: | The game has been created and started |
-| Flow: | **Main Flow** <br> 1. Primary user attempts to move a piece <br> 2. The move is verified as valid <br> 3. The piece is moved <br> 4. The secondary user is notified that it is their turn <br> **Alternate Flows** <br> 2a. The user is notified that the move is invalid <br> 4b. The primary user's move is verified as a winning move and both players are notified the primary user has won the game |
+| Flow: | **Main Flow** <br> 1. Primary user attempts to move a piece <br> 2. The move is verified as valid <br> 3. The piece is moved <br> 4. The secondary user is notified that it is their turn <br> **Alternate Flows** <br> 2a. The user is notified that the move is invalid <br> 4b. The primary user's move is verified as a winning move and both players are notified the primary user has won the game. 1a. A user quits. <br> Include(Quit Match)  |
 | Post-conditions: | The primary user executed a valid move and the game state has been updated |
 
 | Use case id: | R10 |
@@ -121,8 +122,8 @@
 | Overview: | The game data is saved in the database|
 | Primary actors: | Database, User[secondary, initiator] |
 | Pre-conditions: | A user executed a winning move or quit the game |
-| Flow: | **Main Flow** <br> 1. The database is updated with the result of the game <br> 2. The user profiles are updated with the results of the game |
-| Post-conditions: | The database and user profiles have been updated with the correct results of the match |
+| Flow: | **Main Flow** <br> 1. The database is updated with the result of the game <br> 2. The user's accounts are updated with the results of the game |
+| Post-conditions: | The database and user accounts have been updated with the correct results of the match |
 
 | Use case id: | R14 |
 | :--- | :--- |
@@ -144,28 +145,30 @@
 
 | Use case id: | R16 |
 | :--- | :--- |
-| Use case name: | View User Profile |
-| Overview: | The user selects a profile to view and the selected user's data is displayed |
+| Use case name: | View User Account |
+| Overview: | The user selects a . user's account to view and the selected user's data is displayed |
 | Actors: | Database [primary], User [initiator] |
 | Pre-conditions: | User is signed in |
-| Flow: | **Main Flow**: 1. The user selects a user's profile they want to view. <br> 2. The selected user's data is retrieved from the database. <br> 3. Retrieved data is displayed to the user. |
-| Post-conditions: | The selected user's match history is displayed |
+| Main Flow: | 1. User searches for a user and attempts to view it. <br> 2. Database retreives the selected user's data. <br> 3. The selected user's data is displayed. |
+| Post-conditions: | The selected user's account is displayed |
+| Alternate Flows: | **2a User not in database** 2a1. Database informs the user that the selected user's account does not exist. |
 
 | Use case id: | R17 |
 | :--- | :--- |
 | Use case name: | Unregister |
 | Overview: | The user deletes their existing account from the database |
 | Actors: |  User [primary, initiator], Database |
-| Pre-conditions: | User is signed in <br> User is viewing their own profile |
-| Main Flow: | 1. User chooses to delete their account. <br> 2. Database asks user to confirm delete account. <br> 3. The user confirms account deletion. <br> Extension Point: Cancel All Outstanding Invites <br> Extension Point: Remove Match History <br> 4. Database removes sign in data associated with the account. <br> 5. The user is signed out. **Alternate Flow:** 3a. The user cancels account deletion <br> 4a. The unregister use case is cancelled |
-| Post-conditions: | The user's account is deleted and they are signed out |
+| Pre-conditions: | User is signed in <br> User is viewing their own account |
+| Main Flow: | 1. User chooses to delete their account. <br> 2. Database asks user to confirm account deletion. <br> 3. The user confirms account deletion. <br> Extension Point: Cancel All Outstanding Invites <br> Extension Point: Remove Match History <br> 4. Database removes sign in data associated with the account. <br> 5. The user is signed out. |
+| Post-conditions: | The user's account is deleted and the user is signed out |
+| Alternate Flows: | **3a User cancels confirmation** 3a1. The user cancels the account deletion. |
 
 | Use case id: | R18 |
 | :--- | :--- |
 | Use case name: | Remove Match History |
 | Overview: | The match history will be associated with a generic user |
 | Actors: |  User [primary, initiator], Database |
-| Pre-conditions: | User has confirmed the account deletetion <br> Database has an instance of generic user that no user has access to |
-| Main Flow: | 1. Database selects the first entry in the user's match history. <br> 2. Database updates the results from the unregister-requesting user to a generic user. <br> 3. Database deletes the match from the user's account. <br> 4. If there are any more, return to 1. |
-| Post-conditions: |  |
-4. Database selects each match recorded in the user's match history, deletes 
+| Pre-conditions: | User confirmed the account deletetion <br> Database has a single instance of generic user that no user has access to |
+| Main Flow: | 1. Database selects the first entry in the user's match history. <br> 2. Database updates the results from the user to the generic user. <br> 3. Database deletes the match from the user's account. <br> 4. If there are any recorded matches associated with the user, return to 1. |
+| Post-conditions: | The database does not contain any matches associated with the user |
+| Alternate Flows: | - |

--- a/UseCaseDocumentation.md
+++ b/UseCaseDocumentation.md
@@ -4,10 +4,11 @@
 | :--- | :--- |
 | Use case name: | Register |
 | Overview: | The user registers an account with their email, username, and password |
-| Actors: | User [primary, initiator] |
+| Actors: | User [primary, initiator], Database |
 | Pre-conditions: | User is prompted to either sign in or register. The user chooses register. |
-| Flow: | **Main Flow** <br> 1. User enters their email, username, and password. <br> 2. User is informed that the email and username are valid. <br> 3. User is automatically signed in in to the newly created account. <br> **Alternate Flows** <br> 2a. User is informed that their email address or username is invalid. <br> 3a. User is allowed another attempt. |
-| Post-conditions: | User is automatically signed in in to the newly created account |
+| Main Flow: | 1. User enters their email, a username, and a password. <br> 2. User attempts to register. <br> 3. Database informs the user that the email, username and password provided are all valid. <br> 4. Database records the new account. <br> 5. User is automatically signed into the new account. |
+| Post-conditions: | User is signed into the new account |
+| Alternate Flows: | **3a Invalid register attempt** <br> 3a1. Database informs the user that the email, username or password provided are invalid. <br> 3a2. User is allowed another attempt. Return to 1. |
 
 | Use case id: | R2 |
 | :--- | :--- |
@@ -15,8 +16,9 @@
 | Overview: | The user signs into their prexisting account with username and password |
 | Actors: | User [primary, initiator], Database |
 | Pre-conditions: | User is prompted to either sign in or register. The user chooses sign in. |
-| Flow: | **Main Flow**: <br> 1. User enters a username and a password. <br> 2. User attempts to sign in. <br> 3. Database informs the user that the username and password combination is valid and the session is saved in the database. <br> 4. The user is redirected to the lobby. <br> **Alternate Flows**: <br> 3a. Invalid sign in <br> 3a1. Database informs the user that the username and password combination is invalid. <br><br> 3a2. User is allowed another attempt. Return to 1. <br> 3b. Inexistent username <br> 3b1. Database informs user that the username provided is not associated to an account. <br> 3b2. User is allowed another attempt. Return to 1. |
+| Main Flow: | 1. User enters a username and a password. <br> 2. User attempts to sign in. <br> 3. Database informs the user that the username and password combination is valid. <br> 4. Database saves the session. |
 | Post-conditions: | User signs into their preexisting account |
+| Alternate Flows: | **3a Invalid sign in attempt** <br> 3a1. Database informs the user that the username and password combination is invalid. <br> 3a2. User is allowed another attempt. Return to 1. <br> **3b Inexistent username** <br> 3b1. Database informs the user that the username provided is not associated to an account. <br> 3b2. User is allowed another attempt. Return to 1. |
 
 | Use case id: | R3 |
 | :--- | :--- |

--- a/UseCaseDocumentation.md
+++ b/UseCaseDocumentation.md
@@ -3,70 +3,71 @@
 | Use case id: | R01 |
 | :--- | :--- |
 | Use case name: | Register |
-| Overview: | The user registers an account with their email, username, and password |
+| Overview: | The user registers an account by providing valid data  |
 | Actors: | User [primary, initiator], Database |
-| Pre-conditions: | User was prompted to either sign in or register. The user chose register. |
-| Main Flow: | 1. User enters an email, a username, and a password. <br> 2. User attempts to register. <br> 3. Database informs the user that the email, username and password provided are all valid. <br> 4. Database records the new account. <br> 5. User is automatically signed into the new account. |
-| Post-conditions: | User is signed into the new account |
-| Alternate Flows: | **3a Invalid data** <br> 3a1. Database informs the user that the email, username or password provided are invalid. <br> 3a2. User is allowed another attempt. Return to 1. |
+| Pre-conditions: | User was prompted to either sign in or register, and chose to register |
+| Main Flow: | 1. User enters an email, a username, and a password. <br> 2. User attempts to register. <br> 3. Database informs the user that the email, username, and password provided are all valid. <br> 4. Database records the new account. <br> 5. User is signed into the new account. |
+| Post-conditions: | User can sign in using the data provided in future attempts |
+| Alternate Flows: | **3a Invalid data** <br> 3a1. Database informs the user that the email, username, or password provided are invalid. <br> 3a2. User is allowed another attempt. Return to 1. |
 
 | Use case id: | R02 |
 | :--- | :--- |
 | Use case name: | Sign In |
-| Overview: | The user signs into their preexisting account with username and password |
+| Overview: | The user signs into their preexisting account |
 | Actors: | User [primary, initiator], Database |
-| Pre-conditions: | User has registered an account. <br> User was prompted to either sign in or register. The user chose sign in. |
+| Pre-conditions: | User has registered an account <br> User was prompted to either sign in or register, and chose to sign in |
 | Main Flow: | 1. User enters a username and a password. <br> 2. User attempts to sign in. <br> 3. Database informs the user that the username and password combination is valid. <br> 4. Database saves the session. |
-| Post-conditions: | User signs into their account |
+| Post-conditions: | User is immediately able to create a match |
 | Alternate Flows: | **3a Invalid data** <br> 3a1. Database informs the user that the username and password combination is invalid. <br> 3a2. User is allowed another attempt. Return to 1. <br> **3b Inexistent username** <br> 3b1. Database informs the user that the username provided is not associated to an account. <br> 3b2. User is allowed another attempt. Return to 1. |
 
 | Use case id: | R03 |
 | :--- | :--- |
 | Use case name: | Create Match |
-| Overview: | The user creates a new match instance |
+| Overview: | A new match is made |
 | Actors: | User [primary, initiator], Database |
 | Pre-conditions: | User is signed in |
-| Main Flow: | 1. User chooses to start a new match. <br> 2. Database creates a new instance of match. <br> 3. Database adds the user to the match. <br> 4. Include(Send Invite). <br> 5. User can send many invites. Return to 4. |
+| Main Flow: | 1. User chooses to start a new match. <br> 2. Database creates a new instance of match. <br> 3. Database adds the user to the match. <br> Extension Point: Send Invite |
 | Post-conditions: | Database creates a new match with one player |
-| Alternate Flows: | **4a No invites** <br> 4a1. User does not send any invites and chooses to play the computer. <br> 4a2. Include(Start Match). |
+| Alternate Flows: | - |
 
 | Use case id: | R04 |
 | :--- | :--- |
 | Use case name: | Send Invite |
-| Overview: | The user invites another user to play a match |
-| Primary actors: | User [primary, initiator] |
+| Overview: | The user invites a user to play their match |
+| Primary actors: | User [primary, initiator], Database |
 | Pre-conditions: | The invitation sender created a match |
-| Main Flow | 1. Inviter sends invitee an invitation to join their match. <br> 2. Database records the pending invite sent from the inviter. <br> 3. Invitee is notified of the pending invitation. |
-| Post-conditions: | User is notified of the invitation |
-| Alternate Flows: | - |
+| Main Flow: | 1. User selects a user to send an invitation to and attempts to send the invitation. <br> 2. The receiver is notified of the invitation. <br> 3. Database records invitation to all user's accounts. <br> Extension Point: Send Invite. |
+| Post-conditions: | Every valid invitation notifies the receiver |
+| Alternate Flows: | **2a Invalid: self invitation** <br> 2a1. Database informs user that they cannot send an invitation to themself. Return to 1. <br> **3b Valid: duplicate invitation** <br> 3b1. Database does not re-record an additional invitation to any user's account. |
 
 | Use case id: | R05 |
 | :--- | :--- |
 | Use case name: | Accept Invite |
-| Overview: | A user accepts an invitation to play a match |
-| Primary actors: | User [primary, initiator] |
-| Pre-conditions: | User has invited the invitee |
-| Flow: | **Main Flow** <br> 1. Primary user receives invite from Initiating User <br> 2. Primary user accepts invite <br> **Alternate Flows** <br> 2a. Primary User rejects invitation |
-| Post-conditions: | Primary User is now in game with Initiating User |
+| Overview: | A user accepts an invite to play a match |
+| Primary actors: | User [primary, initiator], Database |
+| Pre-conditions: | The receiving user was notified of the invitation |
+| Main Flow: | 1. The receiver is prompted to either accept or reject the invitation, and chooses to accept. <br> 2. Database informs the sender that an invitation has been accepted. <br> 3. Database adds the accepted receiver to the match. <br> Extension Point: Cancel All Outstanding Invitations <br> Include(Start Game) |
+| Post-conditions: | The first user that accepted the invitation is in the match |
+| Alternate Flows: | - |
 
 | Use case id: | R06 |
 | :--- | :--- |
 | Use case name: | Reject Invite |
-| Overview: | The user rejects an invitation to play a game with another user |
-| Primary actors: | User [primary, initiator] |
-| Pre-conditions: | The user is sent an invitation to play a game by another user. |
-| Flow: | Main flow: 1. The user chooses to reject the invitation and does not join the game. |
-| Post-conditions: | The user is not added to the game. |
-
+| Overview: | A user rejects an invite to play a match |
+| Primary actors: | User [primary, initiator], Database |
+| Pre-conditions: | The receiving user was notified of the invitation |
+| Main Flow: | 1. The receiver is prompted to either accept or reject the invitation, and choose to reject. <br> 2. Database informs the sender that the invitation has been rejected. <br> 3. Database deletes the invitation from both user's accounts. |
+| Post-conditions: | - |
+| Alternate Flows: | - |
 
 | Use case id: | R07 |
 | :--- | :--- |
-| Use case name: | Join Match |
-| Overview: | Invited user joins the match |
-| Primary actors: | User [primary, initiator] |
-| Pre-conditions: | User receives an invitation to play a match |
-| Main Flow: | <br> 1. User accepts invitation to join a match. <br> 2. User is loaded into the match |
-| Post-conditions: | User is now in a match |
+| Use case name: | Cancel All Outstanding Invitations |
+| Overview: | All of the sending user's pending invites are cancelled |
+| Primary actors: | Database [primary, initiator] |
+| Pre-conditions: | An invitation has been accepted by a receiver |
+| Main Flow: | 1. Database selects a sent invite from the sending user's account. <br> 2. Database informs the receiving user that the invite has been cancelled. <br> 3. Database deletes the pending invite from both user's accounts. <br> Extension Point: Cancel All Outstanding Invitations |
+| Post-conditions: | The invitation sender's account does not contain pending sent invitations |
 | Alternate Flows: | - |
 
 | Use case id: | R08 |
@@ -89,59 +90,14 @@
 
 | Use case id: | R10 |
 | :--- | :--- |
-| Use case name: | Finish Match |
-| Overview: | The game data is saved in the database|
-| Primary actors: | Database, User[secondary, initiator] |
-| Pre-conditions: | A user executed a winning move or quit the game |
-| Flow: | **Main Flow** <br> 1. The database is updated with the result of the game <br> 2. The user profiles are updated with the results of the game |
-| Post-conditions: | The database and user profiles have been updated with the correct results of the match |
+| Use case name: | Enforce Rules |
+| Overview: | The user or opponent make a valid move and the state of the game changes. |
+| Primary actors: | User [Primary, Initiator] |
+| Pre-conditions: | The user is playing a game. |
+| Flow: | **Main Flow**: 1. User or opponent makes a move. <br> 2. The state is changed according to the game rules. |
+| Post-conditions: | It is the other players turn. |
 
 | Use case id: | R11 |
-| :--- | :--- |
-| Use case name: | Quit Match |
-| Overview: | The user quits the match |
-| Primary actors: | User [primary, initiator] |
-| Pre-conditions: | A game is in progress |
-| Flow: | **Main Flow** <br> 1. The user elects to quit that game <br> 2. The secondary user is notified that the primary user has quit |
-| Post-conditions: | The game is ended |
-
-| Use case id: | R12 |
-| :--- | :--- |
-| Use case name: | Unregister |
-| Overview: | The user deletes their existing account from the system |
-| Actors: |  User [primary, initiator] |
-| Pre-conditions: | The user is signed in |
-| Flow: | **Main Flow:** 1. The user chooses to delete their account<br> 2. The system asks user to confirm delete account<br> 3. The user confirms account deletion<br> The system deletes the user's account<br> 4. The user is signed out<br> **Alternate Flow:** 3a. The user cancels account deletion<br> 4a.The unregister use case is cancelled|
-| Post-conditions: | The user's account is deleted and they are signed out |
-
-| Use case id: | R13 |
-| :--- | :--- |
-| Use case name: | Record Match History |
-| Overview: | The results of the match are stored in the database |
-| Actors: | Database [primary], User [initiator] |
-| Pre-conditions: | The match has ended |
-| Flow: | **Main Flow**: <br> 1. The start and end times and dates are recorded to the database. <br> 2. The winner and loser are recorded to the database. <br> **Alternate Flows**: <br> 2a A user quits <br> 2a1. The user that quit the match is recorded to the database as the loser and the other user is recorded as the winner. <br> 2a2. The user that quit is recorded to have withdrawn from the match. |
-| Post-conditions: | The times, dates and results are stored in the database |
-
-| Use case id: | R14 |
-| :--- | :--- |
-| Use case name: | View User Profile |
-| Overview: | The user selects a profile to view and the selected user's data is displayed |
-| Actors: | Database [primary], User [initiator] |
-| Pre-conditions: | User is signed in |
-| Flow: | **Main Flow**: 1. The user selects a user's profile they want to view. <br> 2. The selected user's data is retrieved from the database. <br> 3. Retrieved data is displayed to the user. |
-| Post-conditions: | The selected user's match history is displayed |
-
-| Use case id: | R15 |
-| :--- | :--- |
-| Use case name: | Save Match State |
-| Overview: | The database saves the game state indefinitely. |
-| Primary actors: | User [Primary, Initiator] |
-| Pre-conditions: | User is currently playing a game. |
-| Flow: | **Main Flow**: 1. User or opponent makes move. <br> 2. User signs off or stops playing. <br> 3. State is saved. <br> 4. User returns. |
-| Post-conditions: | The game is ready to be played where the user left off. |
-
-| Use case id: | R16 |
 | :--- | :--- |
 | Use case name: | Notify User When It Is Their Turn |
 | Overview: | The opponent's turn ends and the user receives a notification that it is their turn. |
@@ -150,11 +106,66 @@
 | Flow: | **Main Flow**: 1. The user receives a notification that it is their turn. |
 | Post-conditions: | It is the user's turn. |
 
+| Use case id: | R12 |
+| :--- | :--- |
+| Use case name: | Save Match State |
+| Overview: | The database saves the game state indefinitely. |
+| Primary actors: | User [Primary, Initiator] |
+| Pre-conditions: | User is currently playing a game. |
+| Flow: | **Main Flow**: 1. User or opponent makes move. <br> 2. User signs off or stops playing. <br> 3. State is saved. <br> 4. User returns. |
+| Post-conditions: | The game is ready to be played where the user left off. |
+
+| Use case id: | R13 |
+| :--- | :--- |
+| Use case name: | Finish Match |
+| Overview: | The game data is saved in the database|
+| Primary actors: | Database, User[secondary, initiator] |
+| Pre-conditions: | A user executed a winning move or quit the game |
+| Flow: | **Main Flow** <br> 1. The database is updated with the result of the game <br> 2. The user profiles are updated with the results of the game |
+| Post-conditions: | The database and user profiles have been updated with the correct results of the match |
+
+| Use case id: | R14 |
+| :--- | :--- |
+| Use case name: | Quit Match |
+| Overview: | The user quits the match |
+| Primary actors: | User [primary, initiator] |
+| Pre-conditions: | A game is in progress |
+| Flow: | **Main Flow** <br> 1. The user elects to quit that game <br> 2. The secondary user is notified that the primary user has quit |
+| Post-conditions: | The game is ended |
+
+| Use case id: | R15 |
+| :--- | :--- |
+| Use case name: | Record Match Results |
+| Overview: | The results of the match are stored in the database |
+| Actors: | Database [primary], User [initiator] |
+| Pre-conditions: | The match has ended |
+| Flow: | **Main Flow**: <br> 1. The start and end times and dates are recorded to the database. <br> 2. The winner and loser are recorded to the database. <br> **Alternate Flows**: <br> 2a A user quits <br> 2a1. The user that quit the match is recorded to the database as the loser and the other user is recorded as the winner. <br> 2a2. The user that quit is recorded to have withdrawn from the match. |
+| Post-conditions: | The times, dates and results are stored in the database |
+
+| Use case id: | R16 |
+| :--- | :--- |
+| Use case name: | View User Profile |
+| Overview: | The user selects a profile to view and the selected user's data is displayed |
+| Actors: | Database [primary], User [initiator] |
+| Pre-conditions: | User is signed in |
+| Flow: | **Main Flow**: 1. The user selects a user's profile they want to view. <br> 2. The selected user's data is retrieved from the database. <br> 3. Retrieved data is displayed to the user. |
+| Post-conditions: | The selected user's match history is displayed |
+
 | Use case id: | R17 |
 | :--- | :--- |
-| Use case name: | Enforce Rules |
-| Overview: | The user or opponent make a valid move and the state of the game changes. |
-| Primary actors: | User [Primary, Initiator] |
-| Pre-conditions: | The user is playing a game. |
-| Flow: | **Main Flow**: 1. User or opponent makes a move. <br> 2. The state is changed according to the game rules. |
-| Post-conditions: | It is the other players turn. |
+| Use case name: | Unregister |
+| Overview: | The user deletes their existing account from the database |
+| Actors: |  User [primary, initiator], Database |
+| Pre-conditions: | User is signed in <br> User is viewing their own profile |
+| Main Flow: | 1. User chooses to delete their account. <br> 2. Database asks user to confirm delete account. <br> 3. The user confirms account deletion. <br> Extension Point: Cancel All Outstanding Invites <br> Extension Point: Remove Match History <br> 4. Database removes sign in data associated with the account. <br> 5. The user is signed out. **Alternate Flow:** 3a. The user cancels account deletion <br> 4a. The unregister use case is cancelled |
+| Post-conditions: | The user's account is deleted and they are signed out |
+
+| Use case id: | R18 |
+| :--- | :--- |
+| Use case name: | Remove Match History |
+| Overview: | The match history will be associated with a generic user |
+| Actors: |  User [primary, initiator], Database |
+| Pre-conditions: | User has confirmed the account deletetion <br> Database has an instance of generic user that no user has access to |
+| Main Flow: | 1. Database selects the first entry in the user's match history. <br> 2. Database updates the results from the unregister-requesting user to a generic user. <br> 3. Database deletes the match from the user's account. <br> 4. If there are any more, return to 1. |
+| Post-conditions: |  |
+4. Database selects each match recorded in the user's match history, deletes 

--- a/UseCaseDocumentation.md
+++ b/UseCaseDocumentation.md
@@ -1,16 +1,16 @@
 # Use Case Documentation
 
-| Use case id: | R1 |
+| Use case id: | R01 |
 | :--- | :--- |
 | Use case name: | Register |
 | Overview: | The user registers an account with their email, username, and password |
 | Actors: | User [primary, initiator], Database |
 | Pre-conditions: | User is prompted to either sign in or register. The user chooses register. |
-| Main Flow: | 1. User enters their email, a username, and a password. <br> 2. User attempts to register. <br> 3. Database informs the user that the email, username and password provided are all valid. <br> 4. Database records the new account. <br> 5. User is automatically signed into the new account. |
+| Main Flow: | 1. User enters an email, a username, and a password. <br> 2. User attempts to register. <br> 3. Database informs the user that the email, username and password provided are all valid. <br> 4. Database records the new account. <br> 5. User is automatically signed into the new account. |
 | Post-conditions: | User is signed into the new account |
 | Alternate Flows: | **3a Invalid register attempt** <br> 3a1. Database informs the user that the email, username or password provided are invalid. <br> 3a2. User is allowed another attempt. Return to 1. |
 
-| Use case id: | R2 |
+| Use case id: | R02 |
 | :--- | :--- |
 | Use case name: | Sign In |
 | Overview: | The user signs into their prexisting account with username and password |
@@ -20,34 +20,35 @@
 | Post-conditions: | User signs into their preexisting account |
 | Alternate Flows: | **3a Invalid sign in attempt** <br> 3a1. Database informs the user that the username and password combination is invalid. <br> 3a2. User is allowed another attempt. Return to 1. <br> **3b Inexistent username** <br> 3b1. Database informs the user that the username provided is not associated to an account. <br> 3b2. User is allowed another attempt. Return to 1. |
 
-| Use case id: | R3 |
+| Use case id: | R03 |
 | :--- | :--- |
 | Use case name: | Create Match |
-| Overview: | The user adds a new game info into the database |
-| Actors: | User [primary, initiator]<br> Database [secondary]|
-| Pre-conditions: | The user is signed in |
-| Flow: | **Main Flow:** 1. The user chooses to start a new match<br> 2. A new game is added to the Database<br> 3. The user is added to the new game lobby|
-| Post-conditions: | A new game is added to the Database and the user is added to it |
+| Overview: | The database creates a new match instance |
+| Actors: | User [primary, initiator], Database |
+| Pre-conditions: | User is signed in |
+| Main Flow: | 1. User chooses to start a new match. <br> 2. Database creates a new instance of match. <br> 3. Database adds the user to the match. |
+| Post-conditions: | Database creates a new match and the user is added to it |
+| Alternate Flows: | - |
 
-| Use case id: | R4 |
+| Use case id: | R04 |
 | :--- | :--- |
 | Use case name: | Join Match |
-| Overview: | User joins the match |
+| Overview: | Invited user joins the match |
 | Primary actors: | User [primary, initiator] |
-| Pre-conditions: | A user is invited to join a match |
-| Flow: |**Main Flow** <br> 1. User accepts invitation to join a match <br> 2. User is loaded into match |
+| Pre-conditions: | User receives an invitation to play a match |
+| Flow: |**Main Flow** <br> 1. User accepts invitation to join a match. <br> 2. User is loaded into the match |
 | Post-conditions: | User is now in a match |
 
-| Use case id: | R5 |
+| Use case id: | R05 |
 | :--- | :--- |
-| Use case name: | Invite Player |
-| Overview: | Initiating User invites Primary User to match |
+| Use case name: | Send Invite |
+| Overview: | User invites another user an invitation to play a match |
 | Primary actors: | User [primary, initiator] |
-| Pre-conditions: | Initiating User created a game |
+| Pre-conditions: | Initiating user created a match |
 | Flow: | **Main Flow** <br> 1. Initiating User invites Primary User to match <br> 2. Primary User joins Match <br> **Alternate Flows** <br> 2a. Primary User does not join match 2a. Initiating user can invite a friend |
 | Post-conditions: | Primary User and Initiating User are in a match |
 
-| Use case id: | R6 |
+| Use case id: | R06 |
 | :--- | :--- |
 | Use case name: | Accept Invite |
 | Overview: | Primary User receives Invitation for a match |
@@ -56,7 +57,7 @@
 | Flow: | **Main Flow** <br> 1. Primary user receives invite from Initiating User <br> 2. Primary user accepts invite <br> **Alternate Flows** <br> 2a. Primary User rejects invitation |
 | Post-conditions: | Primary User is now in game with Initiating User |
 
-| Use case id: | R7 |
+| Use case id: | R07 |
 | :--- | :--- |
 | Use case name: | Reject Invite |
 | Overview: | The user rejects an invitation to play a game with another user |
@@ -65,7 +66,7 @@
 | Flow: | Main flow: 1. The user chooses to reject the invitation and does not join the game. |
 | Post-conditions: | The user is not added to the game. |
 
-| Use case id: | R8 |
+| Use case id: | R08 |
 | :--- | :--- |
 | Use case name: | Start Match |
 | Overview: | All users are added to a new game and game is marked in progress |
@@ -74,7 +75,7 @@
 | Flow: | **Main Flow:** 1. The users choose to start the game<br> 2. A new game instance is made<br> 3. All users in lobby are added to the game<br> **Alternate Flow:** 1a. The users quit the lobby<br> 2a. The game lobby is removed from the Database<br> 3a. The start game use case is cancelled|
 | Post-conditions: | A new game instance is started and all users are added to the game |
 
-| Use case id: | R9 |
+| Use case id: | R09 |
 | :--- | :--- |
 | Use case name: | Play Match |
 | Overview: | Primary User makes a move |

--- a/UseCaseDocumentation.md
+++ b/UseCaseDocumentation.md
@@ -151,7 +151,7 @@
 | Pre-conditions: | User is signed in |
 | Main Flow: | 1. User searches by username and attempts to view it. <br> 2. Database retreives the selected user's account. <br> 3. The selected user's account is displayed. |
 | Post-conditions: | The selected user's account is displayed |
-| Alternate Flows: | **2a User not in database** 2a1. Database informs the user that the username is not associated to an account. |
+| Alternate Flows: | **2a User not in database** <br>2a1. Database informs the user that the username is not associated to an account. |
 
 | Use case id: | R17 |
 | :--- | :--- |
@@ -161,7 +161,7 @@
 | Pre-conditions: | User is signed in <br> User is viewing their own account |
 | Main Flow: | 1. User chooses to delete their account. <br> 2. Database asks user to confirm account deletion. <br> 3. The user confirms account deletion. <br> Extension Point: Cancel All Outstanding Invites <br> Extension Point: Remove Match History <br> 4. Database removes sign in data associated with the account. <br> 5. The user is signed out. |
 | Post-conditions: | The user's account is deleted and the user is signed out |
-| Alternate Flows: | **3a User cancels confirmation** 3a1. The user cancels the account deletion. |
+| Alternate Flows: | **3a User cancels confirmation** <br> 3a1. The user cancels the account deletion. |
 
 | Use case id: | R18 |
 | :--- | :--- |


### PR DESCRIPTION
I'd prefer if multiple people to checked my fixes, as this will affect our grade as a group.
I changed the flow to break it up: Is everyone okay with this? I think it's easier to read now.
**Critical** I think my new R18 is _design_-oriented, and _may_ not need to be in the **use cases**. 
Check out the alternate flows in R4: should the second one be 3a, or leave it as 3b? 

Still needs to be updated:
- R9
- R10
- R11
- R12
- R13
- R14
- R15
When updating, make sure you use the same common nouns found throughout.
Also, syntax should be uniform, but you don't _really_ need to pay attention to these too hard. I can clean them up a bit after yours are merged. 