### PR TITLE
Enter key on Login and Register pages

### DIFF
--- a/src/main/edu/colostate/cs/cs414/method_men/jungle/client/gui/LoginPage.java
+++ b/src/main/edu/colostate/cs/cs414/method_men/jungle/client/gui/LoginPage.java
@@ -37,6 +37,7 @@ public class LoginPage extends Page implements ActionListener{
 
         c.insets = new Insets(0,0,0,0);
         tfUsername = new JTextField(15);
+        tfUsername.addActionListener(this);
         c.gridx = 1;
         c.gridy = 1;
         c.insets = new Insets(75,0,0,100);
@@ -54,6 +55,7 @@ public class LoginPage extends Page implements ActionListener{
 
         c.insets = new Insets(0,0,0,0);
         pfPassword = new JPasswordField(15);
+        pfPassword.addActionListener(this);
         c.gridx = 1;
         c.gridy = 2;
         c.insets = new Insets(0,0,0,100);
@@ -112,7 +114,8 @@ public class LoginPage extends Page implements ActionListener{
                 frame.changePageTo(new StartPage(frame));
                 break;
 
-            case "Login":
+            // if any new cases are added, put them above this line
+            default: // Default case happens either when Login button is clicked of Enter key is pressed
                 boolean authLogin = false;
                 if(getUsername().equals("") || getPassword().equals("")){
                     JOptionPane.showMessageDialog(frame,
@@ -145,9 +148,6 @@ public class LoginPage extends Page implements ActionListener{
                     break;
                 }
 
-
-            default:
-                break;
         }
     }
 }

--- a/src/main/edu/colostate/cs/cs414/method_men/jungle/client/gui/RegisterPage.java
+++ b/src/main/edu/colostate/cs/cs414/method_men/jungle/client/gui/RegisterPage.java
@@ -38,6 +38,7 @@ public class RegisterPage extends Page implements ActionListener{
         gridbag.setConstraints(lbUsername,c);
 
         tfUsername = new JTextField(20);
+        tfUsername.addActionListener(this);
         c.gridx = 1;
         c.gridy = 0;
         c.insets = new Insets(75,0,0,100);
@@ -56,6 +57,7 @@ public class RegisterPage extends Page implements ActionListener{
 
         c.insets = new Insets(0,0,0,0);
         pfPassword = new JPasswordField(20);
+        pfPassword.addActionListener(this);
         c.gridx = 1;
         c.gridy = 1;
         c.insets = new Insets(0,0,0,100);
@@ -74,6 +76,7 @@ public class RegisterPage extends Page implements ActionListener{
 
         c.insets = new Insets(0,0,0,0);
         pfVerifyPassword = new JPasswordField(20);
+        pfVerifyPassword.addActionListener(this);
         c.gridx = 1;
         c.gridy = 2;
         c.insets = new Insets(0,0,0,100);
@@ -134,7 +137,8 @@ public class RegisterPage extends Page implements ActionListener{
                 frame.changePageTo(new StartPage(frame));
                 break;
 
-            case "Register":
+            // if any new cases are added, put them above this line
+            default: // Default case happens when the ether Register button is clicked or Enter key is pressed
                 //Passwords don't match
                 if(!getPassword().equals(getVerifyPassword())){
                     JOptionPane.showMessageDialog(frame,
@@ -179,6 +183,7 @@ public class RegisterPage extends Page implements ActionListener{
                                 JOptionPane.ERROR_MESSAGE);
                         tfUsername.setText("");
                         pfPassword.setText("");
+                        pfVerifyPassword.setText("");
                         break;
                     }
 


### PR DESCRIPTION
# Description

* You can now use the enter key to login and register.
* The button still works, but enter key is a faster alternative.

# Checklist
 - [x] Unit Tests Passing

# Notes 
* Also fixed issue with password fields not clearing when register is invalid